### PR TITLE
FIX: Fix link

### DIFF
--- a/doc/connectivity/connectome_extraction.rst
+++ b/doc/connectivity/connectome_extraction.rst
@@ -68,7 +68,7 @@ of the estimator::
     >>> estimator.precision_  # doctest: +SKIP
 
 
-.. |covariance| image:: ../auto_examples/03_connectivity/images/sphx_glr_plot_inverse_covariance_connectome_001.png
+.. |covariance| image:: ../_images/sphx_glr_plot_inverse_covariance_connectome_001.png
     :target: ../auto_examples/03_connectivity/plot_inverse_covariance_connectome.html
     :scale: 40
 .. |precision| image:: ../auto_examples/03_connectivity/images/sphx_glr_plot_inverse_covariance_connectome_003.png


### PR DESCRIPTION
Okay figured out how to fix this one. Verified by running:
```
sphinx-build -D sphinx_gallery_conf.filename_pattern=plot_simulated_connectome -d _build/doctrees . _build/html
```
And looking at `doc/_build/html/connectivity/connectome_extraction.html` to ensure the image was actually there.